### PR TITLE
Update version of twilio chat plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "cordova": "^10.0.0",
     "cordova-android": "^8.1.0",
     "cordova-ios": "^5.0.1",
-    "cordova-plugin-twilio-chat": "^3.3.0",
+    "cordova-plugin-twilio-chat": "^4.0.0",
     "cordova-plugin-whitelist": "^1.3.4",
     "phonegap-plugin-push": "^2.3.0"
   },


### PR DESCRIPTION
This PR bumps the version of the twilio chat plugin to 4.0.0.